### PR TITLE
Makes the API URL an environment URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API=http://localhost:8000

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_API=https://dtang-in-memory-api.herokuapp.com

--- a/src/App.js
+++ b/src/App.js
@@ -8,8 +8,7 @@ import {
 } from "react-router-dom";
 import "./App.css";
 
-// const API = "https://dtang-in-memory-api.herokuapp.com";
-const API = "http://localhost:8000";
+const API = process.env.REACT_APP_API;
 
 export default class App extends React.Component {
   render() {


### PR DESCRIPTION
Note: Normally add environment variable files to `.gitignore` since they often times contain keys that you don't want committed to your repo.